### PR TITLE
Add suuport for x86_64-linux-android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "android_system_properties"
 description = "Minimal Android system properties wrapper"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -17,4 +17,4 @@ keywords = [
 libc = "0.2.126"
 
 [package.metadata.docs.rs]
-targets = ["arm-linux-androideabi", "armv7-linux-androideabi", "aarch64-linux-android", "i686-linux-android", "x86_64-unknown-linux-gnu"]
+targets = ["arm-linux-androideabi", "armv7-linux-androideabi", "aarch64-linux-android", "i686-linux-android", "x86_64-linux-android", "x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
It should work fine on `x86_64-linux-android` too. Tested on Bluestacks VM.