### PR TITLE
Refactor

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -19,6 +19,9 @@ type SystemPropertyReadCallbackFn = unsafe extern "C" fn(*const c_void, Callback
 #[derive(Debug)]
 struct LibC(NonNull<c_void>);
 
+unsafe impl Send for LibC {}
+unsafe impl Sync for LibC {}
+
 impl LibC {
     fn new() -> Option<Self> {
         let c = unsafe { libc::dlopen(b"libc.so\0".as_ptr().cast(), libc::RTLD_NOLOAD) };

--- a/src/android.rs
+++ b/src/android.rs
@@ -74,9 +74,11 @@ impl Implementation {
         })
     }
 
-    unsafe fn new(libc_so: *mut c_void) -> Option<Self> {
-        Self::load_new(libc_so)
-            .or_else(|| Self::load_old(libc_so))
+    fn new(libc_so: &mut LibC) -> Option<Self> {
+        unsafe {
+            Self::load_new(libc_so.as_mut())
+                .or_else(|| Self::load_old(libc_so.as_mut()))
+        }
     }
 
     fn get(&self, cname: *const c_char) -> Option<String> {
@@ -124,7 +126,7 @@ impl Properties {
     /// Create an entry point for accessing Android properties.
     pub(crate) fn new() -> Option<Self> {
         let mut libc_so = LibC::new()?;
-        let implementation = unsafe { Implementation::new(libc_so.as_mut())? };
+        let implementation = Implementation::new(&mut libc_so)?;
         Some(Self { libc_so, implementation })
     }
 

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::{CStr, CString},
+    ffi::CStr,
     mem,
     os::raw::{c_char, c_int, c_void},
     ptr::NonNull,
@@ -130,8 +130,7 @@ impl Properties {
         Some(Self { libc_so, implementation })
     }
 
-    pub(crate) fn get(&self, name: &str) -> Option<String> {
-        let cname = CString::new(name).ok()?;
+    pub(crate) fn get(&self, cname: &CStr) -> Option<String> {
         self.implementation.get(cname.as_ptr().cast())
     }
 }

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,0 +1,133 @@
+use std::{
+    ffi::{CStr, CString},
+    mem,
+    os::raw::{c_char, c_int, c_void},
+};
+
+unsafe fn property_callback(payload: *mut String, _name: *const c_char, value: *const c_char, _serial: u32) {
+    let cvalue = CStr::from_ptr(value);
+    (*payload) = cvalue.to_str().unwrap().to_string();
+}
+
+type Callback = unsafe fn(*mut String, *const c_char, *const c_char, u32);
+
+type SystemPropertyGetFn = unsafe extern "C" fn(*const c_char, *mut c_char) -> c_int;
+type SystemPropertyFindFn = unsafe extern "C" fn(*const c_char) -> *const c_void;
+type SystemPropertyReadCallbackFn = unsafe extern "C" fn(*const c_void, Callback, *mut String) -> *const c_void;
+
+#[derive(Debug)]
+enum Implementation {
+    New {
+        find_fn: SystemPropertyFindFn,
+        read_callback_fn: SystemPropertyReadCallbackFn,
+    },
+    Old {
+        get_fn: SystemPropertyGetFn,
+    }
+}
+
+unsafe fn load_fn(libc_so: *mut c_void, cname: &[u8]) -> Option<*const c_void> {
+    match libc::dlsym(libc_so, cname.as_ptr().cast()) {
+        func if !func.is_null() => Some(func),
+        _ => None,
+    }
+}
+
+impl Implementation {
+    unsafe fn load_new(libc_so: *mut c_void) -> Option<Implementation> {
+        let read_callback_fn = load_fn(libc_so, b"__system_property_read_callback\0")?;
+        let find_fn = load_fn(libc_so, b"__system_property_find\0")?;
+        Some(Implementation::New {
+            find_fn: mem::transmute(find_fn),
+            read_callback_fn: mem::transmute(read_callback_fn),
+        })
+    }
+
+    unsafe fn load_old(libc_so: *mut c_void) -> Option<Implementation> {
+        let get_fn = load_fn(libc_so, b"__system_property_get\0")?;
+        Some(Implementation::Old {
+            get_fn: mem::transmute(get_fn),
+        })
+    }
+
+    unsafe fn new(libc_so: *mut c_void) -> Option<Self> {
+        Self::load_new(libc_so)
+            .or_else(|| Self::load_old(libc_so))
+    }
+
+    fn get(&self, cname: *const c_char) -> Option<String> {
+        match self {
+            Implementation::New { find_fn, read_callback_fn } => {
+                let info = unsafe { (find_fn)(cname) };
+
+                if info.is_null() {
+                    return None;
+                }
+
+                let mut result = String::new();
+
+                unsafe { (read_callback_fn)(info, property_callback, &mut result) };
+
+                Some(result)
+            }
+            Implementation::Old { get_fn } => {
+                // The constant is PROP_VALUE_MAX in Android's libc/include/sys/system_properties.h
+                const PROPERTY_VALUE_MAX: usize = 92;
+                let mut buffer: Vec<u8> = Vec::with_capacity(PROPERTY_VALUE_MAX);
+                let raw = buffer.as_mut_ptr().cast();
+
+                let len = unsafe { (get_fn)(cname, raw) };
+
+                if len > 0 {
+                    assert!(len as usize <= buffer.capacity());
+                    unsafe { buffer.set_len(len as usize); }
+                    String::from_utf8(buffer).ok()
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Properties {
+    libc_so: *mut c_void,
+    implementation: Option<Implementation>,
+}
+
+impl Properties {
+    /// Create an entry point for accessing Android properties.
+    pub(crate) fn new() -> Self {
+        let libc_so = unsafe { libc::dlopen(b"libc.so\0".as_ptr().cast(), libc::RTLD_NOLOAD) };
+
+        let mut properties = Self {
+            libc_so,
+            implementation: None,
+        };
+
+        if libc_so.is_null() {
+            return properties;
+        }
+
+        properties.implementation = unsafe { Implementation::new(libc_so) };
+
+        properties
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<String> {
+        let implementation = self.implementation.as_ref()?;
+        let cname = CString::new(name).ok()?;
+        implementation.get(cname.as_ptr().cast())
+    }
+}
+
+impl Drop for Properties {
+    fn drop(&mut self) {
+        if !self.libc_so.is_null() {
+            unsafe {
+                libc::dlclose(self.libc_so);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ mod android;
 /// ```
 pub struct AndroidSystemProperties {
     #[cfg(target_os = "android")]
-    properties: android::Properties,
+    properties: Option<android::Properties>,
 }
 
 impl AndroidSystemProperties {
@@ -86,6 +86,6 @@ impl AndroidSystemProperties {
         return (name, None).1;
 
         #[cfg(target_os = "android")]
-        return self.properties.get(name);
+        return self.properties.as_ref()?.get(name);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,105 +37,7 @@
 //! [LICENSE-MIT]: https://github.com/nical/android_system_properties/blob/804681c5c1c93d4fab29c1a2f47b7d808dc70fd3/LICENSE-MIT
 
 #[cfg(target_os = "android")]
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw::{c_char, c_int, c_void},
-};
-
-#[cfg(target_os = "android")]
-unsafe fn property_callback(payload: *mut String, _name: *const c_char, value: *const c_char, _serial: u32) {
-    let cvalue = CStr::from_ptr(value);
-    (*payload) = cvalue.to_str().unwrap().to_string();
-}
-
-#[cfg(target_os = "android")]
-type Callback = unsafe fn(*mut String, *const c_char, *const c_char, u32);
-
-#[cfg(target_os = "android")]
-type SystemPropertyGetFn = unsafe extern "C" fn(*const c_char, *mut c_char) -> c_int;
-#[cfg(target_os = "android")]
-type SystemPropertyFindFn = unsafe extern "C" fn(*const c_char) -> *const c_void;
-#[cfg(target_os = "android")]
-type SystemPropertyReadCallbackFn = unsafe extern "C" fn(*const c_void, Callback, *mut String) -> *const c_void;
-
-#[cfg(target_os = "android")]
-#[derive(Debug)]
-enum Implementation {
-    New {
-        find_fn: SystemPropertyFindFn,
-        read_callback_fn: SystemPropertyReadCallbackFn,
-    },
-    Old {
-        get_fn: SystemPropertyGetFn,
-    }
-}
-
-#[cfg(target_os = "android")]
-unsafe fn load_fn(libc_so: *mut c_void, cname: &[u8]) -> Option<*const c_void> {
-    match libc::dlsym(libc_so, cname.as_ptr().cast()) {
-        func if !func.is_null() => Some(func),
-        _ => None,
-    }
-}
-
-#[cfg(target_os = "android")]
-impl Implementation {
-    unsafe fn load_new(libc_so: *mut c_void) -> Option<Implementation> {
-        let read_callback_fn = load_fn(libc_so, b"__system_property_read_callback\0")?;
-        let find_fn = load_fn(libc_so, b"__system_property_find\0")?;
-        Some(Implementation::New {
-            find_fn: mem::transmute(find_fn),
-            read_callback_fn: mem::transmute(read_callback_fn),
-        })
-    }
-
-    unsafe fn load_old(libc_so: *mut c_void) -> Option<Implementation> {
-        let get_fn = load_fn(libc_so, b"__system_property_get\0")?;
-        Some(Implementation::Old {
-            get_fn: mem::transmute(get_fn),
-        })
-    }
-
-    unsafe fn new(libc_so: *mut c_void) -> Option<Self> {
-        Self::load_new(libc_so)
-            .or_else(|| Self::load_old(libc_so))
-    }
-
-    fn get(&self, cname: *const c_char) -> Option<String> {
-        match self {
-            Implementation::New { find_fn, read_callback_fn } => {
-                let info = unsafe { (find_fn)(cname) };
-
-                if info.is_null() {
-                    return None;
-                }
-
-                let mut result = String::new();
-
-                unsafe { (read_callback_fn)(info, property_callback, &mut result) };
-
-                Some(result)
-            }
-            Implementation::Old { get_fn } => {
-                // The constant is PROP_VALUE_MAX in Android's libc/include/sys/system_properties.h
-                const PROPERTY_VALUE_MAX: usize = 92;
-                let mut buffer: Vec<u8> = Vec::with_capacity(PROPERTY_VALUE_MAX);
-                let raw = buffer.as_mut_ptr().cast();
-
-                let len = unsafe { (get_fn)(cname, raw) };
-
-                if len > 0 {
-                    assert!(len as usize <= buffer.capacity());
-                    unsafe { buffer.set_len(len as usize); }
-                    String::from_utf8(buffer).ok()
-                } else {
-                    None
-                }
-            }
-        }
-    }
-}
+mod android;
 
 #[derive(Debug)]
 /// An object that can retrieve android system properties.
@@ -153,35 +55,16 @@ impl Implementation {
 /// ```
 pub struct AndroidSystemProperties {
     #[cfg(target_os = "android")]
-    libc_so: *mut c_void,
-    #[cfg(target_os = "android")]
-    implementation: Option<Implementation>,
+    properties: android::Properties,
 }
 
 impl AndroidSystemProperties {
-    #[cfg(not(target_os = "android"))]
     /// Create an entry point for accessing Android properties.
     pub fn new() -> Self {
-        AndroidSystemProperties {}
-    }
-
-    #[cfg(target_os = "android")]
-    /// Create an entry point for accessing Android properties.
-    pub fn new() -> Self {
-        let libc_so = unsafe { libc::dlopen(b"libc.so\0".as_ptr().cast(), libc::RTLD_NOLOAD) };
-
-        let mut properties = AndroidSystemProperties {
-            libc_so,
-            implementation: None,
-        };
-
-        if libc_so.is_null() {
-            return properties;
+        Self {
+            #[cfg(target_os = "android")]
+            properties: android::Properties::new(),
         }
-
-        properties.implementation = unsafe { Implementation::new(libc_so) };
-
-        properties
     }
 
     /// Retrieve a system property.
@@ -203,21 +86,6 @@ impl AndroidSystemProperties {
         return (name, None).1;
 
         #[cfg(target_os = "android")]
-        return {
-            let implementation = self.implementation.as_ref()?;
-            let cname = CString::new(name).ok()?;
-            implementation.get(cname.as_ptr().cast())
-        };
-    }
-}
-
-#[cfg(target_os = "android")]
-impl Drop for AndroidSystemProperties {
-    fn drop(&mut self) {
-        if !self.libc_so.is_null() {
-            unsafe {
-                libc::dlclose(self.libc_so);
-            }
-        }
+        return self.properties.get(name);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,30 @@ impl AndroidSystemProperties {
         return (name, None).1;
 
         #[cfg(target_os = "android")]
+        return self.properties.as_ref()?.get(&std::ffi::CString::new(name).ok()?);
+    }
+
+    /// Retrieve a system property using a [`CStr`] key.
+    ///
+    /// Returns None if the operation fails.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use android_system_properties::AndroidSystemProperties;
+    /// # use std::ffi::CStr;
+    /// let properties = AndroidSystemProperties::new();
+    ///
+    /// let key = unsafe { CStr::from_bytes_with_nul_unchecked(b"persist.sys.timezone\0") };
+    /// if let Some(value) = properties.get_from_cstr(key) {
+    ///     println!("{}", value);
+    /// }
+    /// ```
+    pub fn get_from_cstr(&self, name: &std::ffi::CStr) -> Option<String> {
+        #[cfg(not(target_os = "android"))]
+        return (name, None).1;
+
+        #[cfg(target_os = "android")]
         return self.properties.as_ref()?.get(name);
     }
 }


### PR DESCRIPTION
* Use an empty struct for non-Android targets.
*  Add enum that decides which implementation to use.
* Split into two files to remove all `#[cfg(target_os = "android")]` guards from the second file.
* Add a struct that wraps the libc.so pointer.
* Declare as send + sync.

The refactored `struct AndroidSystemProperties` has the same interface, and the same size as before.